### PR TITLE
Fix Iron Sight bug with Colt 635 SMG

### DIFF
--- a/System/SwatEquipment.ini
+++ b/System/SwatEquipment.ini
@@ -2151,8 +2151,8 @@ Bulk=22.464
 ;; Viewmodel and Zoom
 FirstPersonModelClass=class'SwatEquipmentModels3.ColtSMG_FirstPerson'
 ThirdPersonModelClass=class'SwatEquipmentModels3.ColtSMG_ThirdPerson'
-IronSightLocationOffset=(X=2,Y=-6.90,Z=5.83)
-IronSightRotationOffset=(Pitch=-285,Yaw=77,Roll=0)
+IronSightLocationOffset=(X=2,Y=-6.90,Z=3.9)
+IronSightRotationOffset=(Pitch=-175,Yaw=77,Roll=0)
 
 ;; GUI
 GUIImage=material'gui_tex3.Equip_ColtSMG'
@@ -2229,8 +2229,8 @@ Bulk=26.464
 ;; Viewmodel and Zoom
 FirstPersonModelClass=class'SwatEquipmentModels3.SilencedColtSMG_FirstPerson'
 ThirdPersonModelClass=class'SwatEquipmentModels3.SilencedColtSMG_ThirdPerson'
-IronSightLocationOffset=(X=2,Y=-6.90,Z=5.83)
-IronSightRotationOffset=(Pitch=-285,Yaw=77,Roll=0)
+IronSightLocationOffset=(X=2,Y=-6.90,Z=3.9)
+IronSightRotationOffset=(Pitch=-175,Yaw=77,Roll=0)
 
 ;; GUI
 GUIImage=material'gui_tex3.Equip_ColtSMG'


### PR DESCRIPTION
Fix:Using the original SEF Colt SMG rotations  of IronSightLocationOffset=(X=2,Y=-6.90,Z=3.9)
IronSightRotationOffset=(Pitch=-175,Yaw=77,Roll=0)

Bugged values: IronSightLocationOffset=(X=2,Y=-6.90,Z=5.83)
IronSightRotationOffset=(Pitch=-285,Yaw=77,Roll=0)