### PR TITLE
Realistic Weight Values

### DIFF
--- a/System/SwatEquipment.ini
+++ b/System/SwatEquipment.ini
@@ -2583,7 +2583,7 @@ EnemyUsesAmmo=(AmmoClass="SwatAmmo.M4A1MG_JHP",Chance=10)
 EnemyUsesAmmo=(AmmoClass="SwatAmmo.M4A1MG_AP",Chance=15)
 
 ;; Weight and Bulk -- need jose fix
-Weight=2.68
+Weight=2.88
 Bulk=22.464
 
 ;; Viewmodel and Zoom
@@ -2721,7 +2721,7 @@ ZoomBlurOverlay=None
 ZoomedFOV=30
 
 ;; Weight and Bulk
-Weight=2.74
+Weight=2.94
 Bulk=22.464
 
 PlayerAmmoOption=SwatAmmo.M4A1MG_AP
@@ -2789,7 +2789,7 @@ OriginalVariant=class'SwatEquipment.M4A1MG'
 PlayerUsable=true
 
 ;; Weight and Bulk
-Weight=3.05
+Weight=3.25
 Bulk=28.812
 
 ;; Viewmodel and Zoom
@@ -2890,7 +2890,7 @@ ZoomedFOV=30
 ZoomBlurOverlay=None
 
 ;; Weight and Bulk
-Weight=3.11
+Weight=3.31
 Bulk=22.464
 
 PlayerAmmoOption=SwatAmmo.M4A1MG_AP

--- a/System/SwatEquipment.ini
+++ b/System/SwatEquipment.ini
@@ -311,7 +311,7 @@ EnemyUsesAmmo=(AmmoClass="SwatAmmo.ColtM1911HG_JHP",Chance=15)
 EnemyUsesAmmo=(AmmoClass="SwatAmmo.ColtM1911HG_AP",Chance=5)
 
 ;; Weight and Bulk
-Weight=1.11
+Weight=1.077
 Bulk=2.9337
 
 ;; Viewmodel and Zoom
@@ -392,7 +392,7 @@ PlayerAmmoOption=SwatAmmo.XDMHG_JSP
 PlayerAmmoOption=SwatAmmo.XDMHG_JHP
 
 ;; Weight and Bulk
-Weight=0.907185
+Weight=0.794	
 Bulk=2.7000
 
 ;; GUI
@@ -460,7 +460,7 @@ PlayerAmmoOption=SwatAmmo.Glock9mmHG_JSP
 PlayerAmmoOption=SwatAmmo.Glock9mmHG_JHP
 
 ;; Weight and Bulk
-Weight=0.74
+Weight=0.705
 Bulk=2.5668
 
 ;; GUI
@@ -539,7 +539,7 @@ PlayerAmmoOption=SwatAmmo.Glock19HG_JSP
 PlayerAmmoOption=SwatAmmo.Glock19HG_JHP
 
 ;; Weight and Bulk
-Weight=0.595
+Weight=0.670
 Bulk=2.3332
 
 ;; GUI
@@ -754,7 +754,7 @@ EnemyUsesAmmo=(AmmoClass="SwatAmmo.BrowHP_JHP",Chance=15)
 EnemyUsesAmmo=(AmmoClass="SwatAmmo.BrowHP_AP",Chance=5)
 
 ;; Weight and Bulk
-Weight=0.9
+Weight=0.91
 Bulk=2.758
 
 ;; Viewmodel and Zoom
@@ -836,7 +836,7 @@ EnemyUsesAmmo=(AmmoClass="SwatAmmo.BrowHPSD_JHP",Chance=15)
 EnemyUsesAmmo=(AmmoClass="SwatAmmo.BrowHPSD_AP",Chance=5)
 
 ;; Weight and Bulk
-Weight=1.08
+Weight=1.28
 Bulk=4.018
 
 ;; Viewmodel and Zoom
@@ -911,7 +911,7 @@ EnemyUsesAmmo=(AmmoClass="SwatAmmo.P226HG_JHP",Chance=15)
 EnemyUsesAmmo=(AmmoClass="SwatAmmo.P226HG_AP",Chance=5)
 
 ;; Weight and Bulk
-Weight=0.79
+Weight=0.96
 Bulk=2.744
 
 ;; Viewmodel and Zoom
@@ -996,7 +996,7 @@ EnemyUsesAmmo=(AmmoClass="SwatAmmo.P226HG_JHP",Chance=15)
 EnemyUsesAmmo=(AmmoClass="SwatAmmo.P226HG_AP",Chance=5)
 
 ;; Weight and Bulk
-Weight=0.79
+Weight=0.94
 Bulk=2.744
 
 ;; Viewmodel and Zoom
@@ -1077,7 +1077,7 @@ EnemyUsesAmmo=(AmmoClass="SwatAmmo.P226SDHG_JHP",Chance=20)
 EnemyUsesAmmo=(AmmoClass="SwatAmmo.P226SDHG_AP",Chance=5)
 
 ;; Weight and Bulk
-Weight=0.95
+Weight=1.33
 Bulk=4.004
 
 ;; Viewmodel and Zoom
@@ -1143,7 +1143,7 @@ EnemyUsesAmmo=(AmmoClass="SwatAmmo2.TEC9SMG_FMJ",Chance=100)
 PlayerAmmoOption=SwatAmmo2.TEC9SMG_FMJ
 
 ;; Weight and Bulk
-Weight=1.50
+Weight=1.40
 Bulk=3.8
 
 ;; Viewmodel and zoom
@@ -1218,6 +1218,10 @@ PlayerAmmoOption=SwatAmmo.Glock18HG_AP
 PlayerAmmoOption=SwatAmmo.Glock18HG_FMJ
 PlayerAmmoOption=SwatAmmo.Glock18HG_JSP
 PlayerAmmoOption=SwatAmmo.Glock18HG_JHP
+
+;; Weight and Bulk
+Weight=0.705
+Bulk=3.000
 
 ;; GUI
 GUIImage=material'gui_sas.glock18'
@@ -1372,7 +1376,7 @@ bIsVariant=true
 OriginalVariant=class'SwatEquipment.FNP90SMG'
 
 ;; Weight and Bulk
-Weight=2.7
+Weight=2.87
 Bulk=14.637
 
 ;; Viewmodel and Zoom
@@ -1427,7 +1431,7 @@ EnemyUsesAmmo=(AmmoClass="SwatAmmo.UZISMG_JHP",Chance=15)
 EnemyUsesAmmo=(AmmoClass="SwatAmmo.UZISMG_AP",Chance=10)
 
 ;; Weight and Bulk
-Weight=4.15
+Weight=4.37
 Bulk=14.15
 
 ;; Viewmodel and Zoom
@@ -1517,7 +1521,7 @@ EnemyUsesAmmo=(AmmoClass="SwatAmmo.MP5SMG_JHP",Chance=15)
 EnemyUsesAmmo=(AmmoClass="SwatAmmo.MP5SMG_AP",Chance=10)
 
 ;; Weight and Bulk
-Weight=3.18
+Weight=3.40
 Bulk=17.42
 
 ;; Viewmodel and Zoom
@@ -1754,7 +1758,7 @@ EnemyUsesAmmo=(AmmoClass="SwatAmmo.MP5SDSMG_JHP",Chance=15)
 EnemyUsesAmmo=(AmmoClass="SwatAmmo.MP5SDSMG_AP",Chance=10)
 
 ;; Weight and Bulk
-Weight=2.25
+Weight=2.37
 Bulk=8.5
 
 ;; Viewmodel and Zoom
@@ -1829,7 +1833,7 @@ ZoomedAutoRecoilBase=160
 bIsVariant=true
 OriginalVariant=class'SwatEquipment.MP5KSMG'
 ;; Weight and Bulk
-Weight=2.3
+Weight=2.67
 Bulk=12.525
 
 ;; GUI
@@ -1898,7 +1902,7 @@ EnemyUsesAmmo=(AmmoClass="SwatAmmo.MP5SMG_JHP",Chance=15)
 EnemyUsesAmmo=(AmmoClass="SwatAmmo.MP5SMG_AP",Chance=10)
 
 ;; Weight and Bulk
-Weight=2.54
+Weight=2.90
 Bulk=17.68
 
 ;; Viewmodel and Zoom
@@ -2028,7 +2032,7 @@ FlashlightRotation_1stPerson=(Pitch=0,Yaw=0,Roll=0)
 FlashlightPosition_3rdPerson=(X=0,Y=-38,Z=5.4)
 FlashlightRotation_3rdPerson=(Pitch=0,Yaw=-16384,Roll=0)
 ;; Weight and Bulk
-Weight=2.78
+Weight=3.27
 Bulk=19.5
 
 ;; GUI
@@ -2098,7 +2102,7 @@ EnemyUsesAmmo=(AmmoClass="SwatAmmo.UMP45SMG_JHP",Chance=15)
 EnemyUsesAmmo=(AmmoClass="SwatAmmo.UMP45SMG_AP",Chance=10)
 
 ;; Weight and Bulk
-Weight=2.44
+Weight=2.30
 Bulk=22.563
 
 ;; Viewmodel and Zoom
@@ -2196,7 +2200,7 @@ bIsVariant=true
 OriginalVariant=class'SwatEquipment.UMP45SMG'
 
 ;; Weight and Bulk
-Weight=2.98
+Weight=2.67
 Bulk=30.2475
 
 ;; Viewmodel and Zoom
@@ -2271,7 +2275,7 @@ EnemyUsesAmmo=(AmmoClass="SwatAmmo.ColtSMG_JHP",Chance=15)
 EnemyUsesAmmo=(AmmoClass="SwatAmmo.ColtSMG_AP",Chance=10)
 
 ;; Weight and Bulk -- need jose fix
-Weight=2.88
+Weight=2.61
 Bulk=22.464
 
 ;; Viewmodel and Zoom
@@ -2346,7 +2350,7 @@ bIsVariant=true
 OriginalVariant=class'SwatEquipment.ColtSMG'
 
 ;; Weight and Bulk -- need jose fix
-Weight=3.18
+Weight=2.98
 Bulk=26.464
 
 ;; Viewmodel and Zoom
@@ -2579,7 +2583,7 @@ EnemyUsesAmmo=(AmmoClass="SwatAmmo.M4A1MG_JHP",Chance=10)
 EnemyUsesAmmo=(AmmoClass="SwatAmmo.M4A1MG_AP",Chance=15)
 
 ;; Weight and Bulk -- need jose fix
-Weight=2.88
+Weight=2.68
 Bulk=22.464
 
 ;; Viewmodel and Zoom
@@ -2654,7 +2658,7 @@ ZoomedAutoRecoilBase=230
 ; Some of the CQB variants aren't modelled yet. Uncomment the lines when they are done, please.
 NoVariantName="Default Configuration"
 SelectableVariants=(VariantName="Aimpoint Sight",VariantClass=class'SwatEquipment.M4A1AMG')
-SelectableVariants=(VariantName="Aimpoint + Suppressor",VariantClass=class'SwatEquipment.M4A1AsdMG')
+;SelectableVariants=(VariantName="Aimpoint + Suppressor",VariantClass=class'SwatEquipment.M4A1AsdMG')
 SelectableVariants=(VariantName="Suppressor",VariantClass=class'SwatEquipment.M4A1sdMG')
 SelectableVariants=(VariantName="Holographic Sight",VariantClass=class'SwatEquipment.M4A1HoloMG')
 SelectableVariants=(VariantName="Holo Sight + Suppressor",VariantClass=class'SwatEquipment.M4A1sdHolo')
@@ -2717,7 +2721,7 @@ ZoomBlurOverlay=None
 ZoomedFOV=30
 
 ;; Weight and Bulk
-Weight=2.88
+Weight=2.74
 Bulk=22.464
 
 PlayerAmmoOption=SwatAmmo.M4A1MG_AP
@@ -2785,7 +2789,7 @@ OriginalVariant=class'SwatEquipment.M4A1MG'
 PlayerUsable=true
 
 ;; Weight and Bulk
-Weight=3.58
+Weight=3.05
 Bulk=28.812
 
 ;; Viewmodel and Zoom
@@ -2886,7 +2890,7 @@ ZoomedFOV=30
 ZoomBlurOverlay=None
 
 ;; Weight and Bulk
-Weight=2.88
+Weight=3.11
 Bulk=22.464
 
 PlayerAmmoOption=SwatAmmo.M4A1MG_AP
@@ -3034,7 +3038,7 @@ EnemyUsesAmmo=(AmmoClass="SwatAmmo.M16MG_JHP",Chance=10)
 EnemyUsesAmmo=(AmmoClass="SwatAmmo.M16MG_AP",Chance=15)
 
 ;; Weight and Bulk
-Weight=3.26
+Weight=3.60
 Bulk=26.078
 
 ;; Viewmodel and Zoom
@@ -3119,7 +3123,7 @@ EnemyUsesAmmo=(AmmoClass="SwatAmmo.M16MG_JHP",Chance=10)
 EnemyUsesAmmo=(AmmoClass="SwatAmmo.M16MG_AP",Chance=15)
 
 ;; Weight and Bulk FIXME
-Weight=3.5
+Weight=3.97
 Bulk=28.418
 
 ;; Viewmodel and Zoom
@@ -3196,7 +3200,7 @@ EnemyUsesAmmo=(AmmoClass="SwatAmmo.AK47MG_LowAmmo_FMJ",Chance=10)
 EnemyUsesAmmo=(AmmoClass="SwatAmmo.AK47MG_AP",Chance=15)
 
 ;; Weight and Bulk
-Weight=3.8
+Weight=4.80
 Bulk=23.4
 
 ;; Viewmodel and Zoom
@@ -3357,7 +3361,7 @@ EnemyUsesAmmo=(AmmoClass="SwatAmmo.AK47MG_LowAmmo_FMJ",Chance=10)
 EnemyUsesAmmo=(AmmoClass="SwatAmmo.AK47MG_AP",Chance=15)
 
 ;; Weight and Bulk
-Weight=4.3
+Weight=4.45
 Bulk=27.4
 
 ;; Viewmodel and Zoom
@@ -3511,7 +3515,7 @@ EnemyUsesAmmo=(AmmoClass="SwatAmmo.SG552MG_JHP",Chance=10)
 EnemyUsesAmmo=(AmmoClass="SwatAmmo.SG552MG_AP",Chance=15)
 
 ;; Weight and Bulk FIXME
-Weight=3.44
+Weight=3.57
 Bulk=21.32
 
 ;; Viewmodel and Zoom
@@ -3663,7 +3667,7 @@ EnemyUsesAmmo=(AmmoClass="SwatAmmo.M4A1MG_JHP",Chance=10)
 EnemyUsesAmmo=(AmmoClass="SwatAmmo.M4A1MG_AP",Chance=15)
 
 ;; Weight and Bulk FIXME
-Weight=3.65
+Weight=3.74
 Bulk=29.44
 
 ;; Viewmodel and Zoom
@@ -3746,7 +3750,7 @@ PlayerAmmoOption=SwatAmmo.G36kMG_JSP
 PlayerAmmoOption=SwatAmmo.G36kMG_JHP
 
 ;; Weight and Bulk
-Weight=4.07
+Weight=3.37		
 Bulk=23.822
 
 ;; Viewmodel and zoom
@@ -3836,7 +3840,7 @@ OriginalVariant=class'SwatEquipment.G36kMG'
 PlayerUsable=true
 
 ;; Weight and Bulk
-Weight=4.67
+Weight=3.74
 Bulk=28.4756
 
 ;; Viewmodel and zoom
@@ -3905,7 +3909,7 @@ PlayerAmmoOption=SwatAmmo2.ColtAR_FMJ
 EnemyUsesAmmo=(AmmoClass="SwatAmmo2.ColtAR_FMJ",Chance=100)
 
 ;; Weight and Bulk
-Weight=4.22
+Weight=4.20
 Bulk=34.102
 
 ;; Firing
@@ -3979,7 +3983,12 @@ SelectableVariants=(VariantName="Integrated Suppressor",VariantClass=class'SwatE
 bIsVariant=true
 OriginalVariant=class'SwatEquipment.ColtAccurizedRifle'
 PlayerUsable=true
-;; TODO: add aiming, weight and recoil information
+
+;; Weight and Bulk
+Weight=4.57
+Bulk=34.102
+
+;; TODO: add aiming and recoil information
 ;; Viewmodel
 FirstPersonModelClass=class'SwatEquipmentModels2.CAR_FirstPerson'
 ThirdPersonModelClass=class'SwatEquipmentModels2.CAR_ThirdPerson'
@@ -4012,7 +4021,7 @@ PlayerAmmoOption=SwatAmmo.M870SGSabotAmmo
 PlayerAmmoOption=SwatAmmo.M870SGAmmo
 
 ;; Weight and Bulk
-Weight=3.19
+Weight=3.63
 Bulk=21.189
 
 ;; Viewmodel
@@ -4089,7 +4098,7 @@ PlayerAmmoOption=SwatAmmo.M4Super90SGSabotAmmo
 PlayerAmmoOption=SwatAmmo.M4Super90SGAmmo
 
 ;; Weight and Bulk
-Weight=3.95
+Weight=3.82
 Bulk=22.22
 
 ;; Viewmodel
@@ -4183,7 +4192,7 @@ PlayerAmmoOption=SwatAmmo.NovaPumpSGSabotAmmo
 PlayerAmmoOption=SwatAmmo.NovaPumpSGAmmo
 
 ;; Weight and Bulk
-Weight=3.89
+Weight=3.63
 Bulk=21.516
 
 ;; Viewmodel
@@ -4259,7 +4268,7 @@ PlayerAmmoOption=SwatAmmo.M870SGSabotAmmo
 PlayerAmmoOption=SwatAmmo.M870SGAmmo
 
 ;; Weight and Bulk
-Weight=3.18
+Weight=3.60
 Bulk=11.952
 
 ;; Viewmodel
@@ -4341,7 +4350,7 @@ PlayerAmmoOption=SwatAmmo.M870SGAmmo
 PlayerAmmoOption=SwatAmmo.M870SGBreachingAmmo
 
 ;; Weight and Bulk
-Weight=3.5
+Weight=3.20
 Bulk=13
 
 ;; Viewmodel
@@ -4419,7 +4428,7 @@ EnemyUsesAmmo=(AmmoClass="SwatAmmo2.HK69GL_StingerGrenadeAmmo",Chance=100)
 MagazineSize=1
 
 ;; Weight and Bulk
-Weight=2.62
+Weight=2.60
 Bulk=9.4915
 
 ;; GUI
@@ -4576,7 +4585,7 @@ PlayerAmmoOption=SwatAmmo2.SAWMG_FMJ
 PlayerAmmoOption=SwatAmmo2.SAWMG_JHP
 
 ;; Weight and Bulk
-Weight=7.71
+Weight=7.5
 Bulk=39.33
 
 ;; GUI
@@ -4703,7 +4712,7 @@ LightstickThrowAnimPostfix="SG"
 IronSightLocationOffset=(X=2,Y=-8,Z=1.9)
 IronSightRotationOffset=(Pitch=425,Yaw=25,Roll=1200)
 
-Weight=3.89
+Weight=3.63
 Bulk=21.516
 WeaponCategory=WeaponClass_LessLethal
 AllowedSlots=WeaponEquip_PrimaryOnly
@@ -4721,7 +4730,7 @@ PlayerAmmoOption=SwatAmmo.LessLethalAmmo
 EnemyUsesAmmo=(AmmoClass="SwatAmmo.LessLethalAmmo",Chance=100)
 
 ;; Weight and Bulk
-Weight=3.18
+Weight=3.60
 Bulk=11.952
 
 ;; Viewmodel
@@ -4854,7 +4863,7 @@ IronSightLocationOffset=(X=1,Y=-7.5,Z=3)
 ;hold it at severe angle so we can use our thumb as the sight
 IronSightRotationOffset=(Pitch=0,Yaw=-100,Roll=2600)
 
-Weight=2.44
+Weight=3.18
 Bulk=17.68
 WeaponCategory=WeaponClass_LessLethal
 AllowedSlots=WeaponEquip_Either
@@ -5010,7 +5019,7 @@ StickToWhat=STICK_TaseablePawns
 
 LightstickThrowAnimPostfix="HG"
 
-Weight=0.544
+Weight=1.25
 Bulk=3.0552
 WeaponCategory=WeaponClass_LessLethal
 AllowedSlots=WeaponEquip_Either
@@ -5165,7 +5174,7 @@ StickToWhat=STICK_TaseablePawns
 
 LightstickThrowAnimPostfix="HG"
 
-Weight=0.48
+Weight=1.35
 Bulk=3.192
 WeaponCategory=WeaponClass_LessLethal
 AllowedSlots=WeaponEquip_Either
@@ -7083,13 +7092,13 @@ UnequipAnimationRate=1.5
 UseAnimationRate=1
 LightstickThrowAnimPostfix="Flash"
 
-Weight=0.42
+Weight=0.236
 Bulk=0.5852
 
 [SwatEquipment.Flashbang3pack]
 PlayerUsable=true
 StartCount=3
-Weight=1.26
+Weight=0.708
 Bulk=0.9753
 
 [SwatEquipment.FlashbangGrenadeProjectile]
@@ -7142,14 +7151,14 @@ UnequipAnimationRate=1.5
 UseAnimationRate=1
 LightstickThrowAnimPostfix="CSGas"
 
-Weight=0.43
+Weight=0.76
 Bulk=0.798
 
 [SwatEquipment.CS3pack]
 PlayerUsable=true
 StartCount=3
 Weight=1.29
-Bulk=1.33
+Bulk=2.28
 
 [SwatEquipment.CSGasGrenadeProjectile]
 ;timer
@@ -7213,13 +7222,13 @@ UnequipAnimationRate=1.5
 UseAnimationRate=1
 LightstickThrowAnimPostfix="StringGrenade"
 
-Weight=0.31
+Weight=0.276
 Bulk=1.036
 
 [SwatEquipment.Sting3pack]
 PlayerUsable=true
 StartCount=3
-Weight=0.93
+Weight=0.828
 Bulk=1.7267
 
 [SwatEquipment.StingGrenadeProjectile]

--- a/System/SwatEquipment.ini
+++ b/System/SwatEquipment.ini
@@ -7151,13 +7151,13 @@ UnequipAnimationRate=1.5
 UseAnimationRate=1
 LightstickThrowAnimPostfix="CSGas"
 
-Weight=0.76
+Weight=0.08
 Bulk=0.798
 
 [SwatEquipment.CS3pack]
 PlayerUsable=true
 StartCount=3
-Weight=1.29
+Weight=0.24
 Bulk=2.28
 
 [SwatEquipment.CSGasGrenadeProjectile]

--- a/System/SwatEquipment.ini
+++ b/System/SwatEquipment.ini
@@ -2658,7 +2658,7 @@ ZoomedAutoRecoilBase=230
 ; Some of the CQB variants aren't modelled yet. Uncomment the lines when they are done, please.
 NoVariantName="Default Configuration"
 SelectableVariants=(VariantName="Aimpoint Sight",VariantClass=class'SwatEquipment.M4A1AMG')
-;SelectableVariants=(VariantName="Aimpoint + Suppressor",VariantClass=class'SwatEquipment.M4A1AsdMG')
+SelectableVariants=(VariantName="Aimpoint + Suppressor",VariantClass=class'SwatEquipment.M4A1AsdMG')
 SelectableVariants=(VariantName="Suppressor",VariantClass=class'SwatEquipment.M4A1sdMG')
 SelectableVariants=(VariantName="Holographic Sight",VariantClass=class'SwatEquipment.M4A1HoloMG')
 SelectableVariants=(VariantName="Holo Sight + Suppressor",VariantClass=class'SwatEquipment.M4A1sdHolo')


### PR DESCRIPTION
After many google searches, I have mostly calculated what I think are the realistic weight values for weapons and grenades. For suppressors, I went with the lightest estimate, which was approximately 0.37 KG. I couldn't find weight values on the Stingray s400 taser, so I added 0.10 kg from the weight of the X26 taser (1.25 KG).